### PR TITLE
Ignore dispatch without a message.

### DIFF
--- a/lib/async/container/supervisor/dispatchable.rb
+++ b/lib/async/container/supervisor/dispatchable.rb
@@ -11,6 +11,7 @@ module Async
 		module Supervisor
 			module Dispatchable
 				def dispatch(call)
+					return unless call.message[:do]
 					method_name = "do_#{call.message[:do]}"
 					self.public_send(method_name, call)
 				rescue => error


### PR DESCRIPTION
Seeing this a couple times an hour:

```
Error while dispatching call.

NoMethodError: undefined method 'do_' for an instance of Async::Container::Supervisor::Server

["/artifacts/bundle/ruby/3.4.0/gems/async-container-supervisor-0.6.1/lib/async/container/supervisor/dispatchable.rb:15:in 'Kernel#public_send'","/artifacts/bundle/ruby/3.4.0/gems/async-container-supervisor-0.6.1/lib/async/container/supervisor/dispatchable.rb:15:in 'Async::Container::Supervisor::Dispatchable#dispatch'","/artifacts/bundle/ruby/3.4.0/gems/async-container-supervisor-0.6.1/lib/async/container/supervisor/connection.rb:79:in 'block in Async::Container::Supervisor::Connection::Call.dispatch'","/artifacts/bundle/ruby/3.4.0/gems/async-2.32.0/lib/async/task.rb:207:in 'block in Async::Task#run'","/artifacts/bundle/ruby/3.4.0/gems/async-2.32.0/lib/async/task.rb:452:in 'block in Async::Task#schedule'"]
```