### PR TITLE
refactor connection to use MessagePack instead of JSON

### DIFF
--- a/bake/async/container/supervisor.rb
+++ b/bake/async/container/supervisor.rb
@@ -44,7 +44,7 @@ def memory_sample(duration: 10, connection_id:)
 		operation = {do: :memory_sample, duration: duration}
 		
 		# Use the forward operation to proxy the request to a worker:
-		return connection.call(do: :forward, operation: operation, connection_id: connection_id)
+		connection.call(do: :forward, operation: operation, connection_id: connection_id)
 	end
 end
 

--- a/examples/simple/simple.rb
+++ b/examples/simple/simple.rb
@@ -33,7 +33,7 @@ class SleepService < Async::Service::Generic
 				Console.info(self, "Exiting...")
 			end
 		end
-	end	
+	end
 end
 
 service "sleep" do

--- a/lib/async/container/supervisor/connection.rb
+++ b/lib/async/container/supervisor/connection.rb
@@ -3,7 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2025, by Samuel Williams.
 
-require "json"
 require "async"
 require_relative "message_wrapper"
 
@@ -14,8 +13,6 @@ module Async
 			#
 			# Handles message passing, call/response patterns, and connection lifecycle.
 			class Connection
-				MAX_MESSAGE_SIZE = 2 ** 32 - 1
-				
 				# Represents a remote procedure call over a connection.
 				#
 				# Manages the call lifecycle, response queueing, and completion signaling.
@@ -38,13 +35,6 @@ module Async
 					# @returns [Hash] The message hash.
 					def as_json(...)
 						@message
-					end
-					
-					# Convert the call to a JSON string.
-					#
-					# @returns [String] The JSON representation.
-					def to_json(...)
-						as_json.to_json(...)
 					end
 					
 					# @attribute [Connection] The connection that initiated the call.

--- a/lib/async/container/supervisor/connection.rb
+++ b/lib/async/container/supervisor/connection.rb
@@ -244,9 +244,6 @@ module Async
 				
 				# Write a message to the connection stream.
 				#
-				# Uses a length-prefixed protocol: 2-byte length header (big-endian) followed by data.
-				# This allows MessagePack data to contain newlines without breaking message boundaries.
-				#
 				# @parameter message [Hash] The message to write.
 				def write(**message)
 					@message_wrapper.write(message)

--- a/lib/async/container/supervisor/message_wrapper.rb
+++ b/lib/async/container/supervisor/message_wrapper.rb
@@ -47,7 +47,7 @@ module Async
 					when Array
 						obj.map{|v| normalize(v)}
 					else
-						if obj.respond_to?(:as_json)
+						if obj.respond_to?(:as_json) && (as_json = obj.as_json) && as_json != obj
 							normalize(obj.as_json)
 						else
 							obj

--- a/lib/async/container/supervisor/message_wrapper.rb
+++ b/lib/async/container/supervisor/message_wrapper.rb
@@ -81,12 +81,13 @@ module Async
 					)
 				end
 				
-				def pack_exception(exception)
-					[exception.class.name, exception.message, exception.backtrace].pack("A*")
+				def pack_exception(exception, packer)
+					message = [exception.class.name, exception.message, exception.backtrace]
+					packer.write(message)
 				end
 				
-				def unpack_exception(data)
-					klass, message, backtrace = data.unpack("A*A*A*")
+				def unpack_exception(unpacker)
+					klass, message, backtrace = unpacker.read
 					klass = Object.const_get(klass)
 					
 					exception = klass.new(message)

--- a/lib/async/container/supervisor/message_wrapper.rb
+++ b/lib/async/container/supervisor/message_wrapper.rb
@@ -20,14 +20,11 @@ module Async
 				
 				def write(message)
 					data = pack(message)
-					# Console.logger.info("Sending data: #{message.inspect}")
 					@packer.write(data)
 				end
 				
 				def read
-					data = @unpacker.read
-					# Console.logger.info("Received data: #{data.inspect}")
-					data
+					@unpacker.read
 				end
 				
 				def pack(message)

--- a/lib/async/container/supervisor/message_wrapper.rb
+++ b/lib/async/container/supervisor/message_wrapper.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require "msgpack"
+
+module Async
+	module Container
+		module Supervisor
+			class MessageWrapper
+				def initialize
+					@factory = MessagePack::Factory.new
+					
+					register_types
+					
+					@packer = @factory.packer
+				end
+				
+				def pack(message)
+					@packer.clear
+					normalized_message = normalize(message)
+					@packer.pack(normalized_message)
+					@packer.full_pack
+				end
+				
+				def unpack(data)
+					@factory.unpack(data)
+				end
+				
+				private
+				
+				def normalize(obj)
+					case obj
+					when Hash
+						obj.transform_values{|v| normalize(v)}
+					when Array
+						obj.map{|v| normalize(v)}
+					else
+						if obj.respond_to?(:as_json)
+							normalize(obj.as_json)
+						else
+							obj
+						end
+					end
+				end
+				
+				def register_types
+					@factory.register_type(0x00, Symbol)
+					
+					@factory.register_type(
+						0x01,
+						Exception,
+						packer: self.method(:pack_exception),
+						unpacker: self.method(:unpack_exception),
+						recursive: true,
+					)
+					
+					@factory.register_type(
+						0x02,
+						Class,
+						packer: ->(klass) {klass.name},
+						unpacker: ->(name) {name},
+					)
+					
+					@factory.register_type(
+						MessagePack::Timestamp::TYPE,
+						Time,
+						packer: MessagePack::Time::Packer,
+						unpacker: MessagePack::Time::Unpacker
+					)
+				end
+				
+				def pack_exception(exception)
+					[exception.class.name, exception.message, exception.backtrace].pack("A*")
+				end
+				
+				def unpack_exception(data)
+					klass, message, backtrace = data.unpack("A*A*A*")
+					klass = Object.const_get(klass)
+					
+					exception = klass.new(message)
+					exception.set_backtrace(backtrace)
+					
+					return exception
+				end
+			end
+		end
+	end
+end

--- a/lib/async/container/supervisor/message_wrapper.rb
+++ b/lib/async/container/supervisor/message_wrapper.rb
@@ -9,12 +9,25 @@ module Async
 	module Container
 		module Supervisor
 			class MessageWrapper
-				def initialize
+				def initialize(stream)
 					@factory = MessagePack::Factory.new
 					
 					register_types
 					
-					@packer = @factory.packer
+					@packer = @factory.packer(stream)
+					@unpacker = @factory.unpacker(stream)
+				end
+				
+				def write(message)
+					data = pack(message)
+					# Console.logger.info("Sending data: #{message.inspect}")
+					@packer.write(data)
+				end
+				
+				def read
+					data = @unpacker.read
+					# Console.logger.info("Received data: #{data.inspect}")
+					data
 				end
 				
 				def pack(message)

--- a/test/async/container/connection.rb
+++ b/test/async/container/connection.rb
@@ -6,7 +6,6 @@
 require "async/container/supervisor/connection"
 require "sus/fixtures/async/scheduler_context"
 require "stringio"
-require "msgpack"
 
 class TestTarget
 	def initialize(&block)

--- a/test/async/container/connection.rb
+++ b/test/async/container/connection.rb
@@ -88,16 +88,6 @@ describe Async::Container::Supervisor::Connection do
 	with subject::Call do
 		let(:test_call) {Async::Container::Supervisor::Connection::Call.new(connection, 1, {do: :test, data: "value"})}
 		
-		it "can serialize call to JSON" do
-			json = test_call.to_json
-			parsed = JSON.parse(json)
-			
-			expect(parsed).to have_keys(
-					"do" => be == "test",
-					"data" => be == "value"
-				)
-		end
-		
 		it "can get call message via as_json" do
 			expect(test_call.as_json).to have_keys(
 					do: be == :test,

--- a/test/async/container/message_wrapper.rb
+++ b/test/async/container/message_wrapper.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require "async/container/supervisor/connection"
+require "sus/fixtures/async/scheduler_context"
+require "stringio"
+require "msgpack"
+
+class TrueObject
+	def as_json
+		true
+	end
+end
+
+describe Async::Container::Supervisor::MessageWrapper do
+	let(:stream) {StringIO.new}
+	let(:message_wrapper) {Async::Container::Supervisor::MessageWrapper.new(stream)}
+	
+	def write_message(message)
+		message_wrapper.write(message)
+		stream.rewind
+	end
+	
+	def read_message
+		message_wrapper.read
+	end
+	
+	with "write and read" do
+		it "normalizes without infinite loop" do
+			Integer.define_method(:as_json) do
+				self
+			end
+			
+			write_message({id: 1, do: :test})
+			
+			message = read_message
+			expect(message[:id]).to be == 1
+		ensure
+			Integer.send(:remove_method, :as_json)
+		end
+		
+		it "handles simple strings" do
+			write_message({message: "hello world"})
+			
+			result = read_message
+			expect(result[:message]).to be == "hello world"
+		end
+		
+		it "handles integers" do
+			write_message({count: 42, negative: -10})
+			
+			result = read_message
+			expect(result[:count]).to be == 42
+			expect(result[:negative]).to be == -10
+		end
+		
+		it "handles floats" do
+			write_message({pi: 3.14159, negative: -2.5})
+			
+			result = read_message
+			expect(result[:pi]).to be == 3.14159
+			expect(result[:negative]).to be == -2.5
+		end
+		
+		it "handles boolean values" do
+			write_message({success: true, failed: false})
+			
+			result = read_message
+			expect(result[:success]).to be == true
+			expect(result[:failed]).to be == false
+		end
+		
+		it "handles nil values" do
+			write_message({empty: nil})
+			
+			result = read_message
+			expect(result[:empty]).to be_nil
+		end
+		
+		it "handles arrays" do
+			write_message({items: [1, 2, 3, "four", true]})
+			
+			result = read_message
+			expect(result[:items]).to be == [1, 2, 3, "four", true]
+		end
+		
+		it "handles nested hashes" do
+			write_message({
+				user: {
+					name: "Alice",
+					details: {
+						age: 30,
+						active: true
+					}
+				}
+			})
+			
+			result = read_message
+			expect(result[:user][:name]).to be == "Alice"
+			expect(result[:user][:details][:age]).to be == 30
+			expect(result[:user][:details][:active]).to be == true
+		end
+		
+		it "handles nested arrays" do
+			write_message({matrix: [[1, 2], [3, 4], [5, 6]]})
+			
+			result = read_message
+			expect(result[:matrix]).to be == [[1, 2], [3, 4], [5, 6]]
+		end
+		
+		it "handles symbols" do
+			write_message({action: :start, status: :success})
+			
+			result = read_message
+			expect(result[:action]).to be == :start
+			expect(result[:status]).to be == :success
+		end
+		
+		it "handles empty hash" do
+			write_message({})
+			
+			result = read_message
+			expect(result).to be == {}
+		end
+		
+		it "handles empty array" do
+			write_message({items: []})
+			
+			result = read_message
+			expect(result[:items]).to be == []
+		end
+	end
+	
+	with "Time handling" do
+		it "serializes and deserializes Time objects" do
+			time = Time.now
+			write_message({timestamp: time})
+			
+			result = read_message
+			expect(result[:timestamp]).to be_within(0.001).of(time)
+		end
+		
+		it "handles Time in nested structures" do
+			time = Time.now
+			write_message({
+				event: {
+					name: "test",
+					occurred_at: time
+				}
+			})
+			
+			result = read_message
+			expect(result[:event][:occurred_at]).to be_within(0.001).of(time)
+		end
+	end
+	
+	with "Class handling" do
+		it "serializes class names" do
+			write_message({type: String})
+			
+			result = read_message
+			expect(result[:type]).to be == "String"
+		end
+		
+		it "handles multiple classes" do
+			write_message({types: [String, Integer, Array]})
+			
+			result = read_message
+			expect(result[:types]).to be == ["String", "Integer", "Array"]
+		end
+	end
+	
+	with "Exception handling" do
+		it "serializes and deserializes RuntimeError" do
+			error = RuntimeError.new("Something went wrong")
+			error.set_backtrace(["line1", "line2"])
+			
+			write_message({error: error})
+			
+			result = read_message
+			expect(result[:error]).to be_a(RuntimeError)
+			expect(result[:error].message).to be == "Something went wrong"
+			expect(result[:error].backtrace).to be == ["line1", "line2"]
+		end
+		
+		it "handles StandardError" do
+			error = StandardError.new("Standard error")
+			write_message({error: error})
+			
+			result = read_message
+			expect(result[:error]).to be_a(StandardError)
+			expect(result[:error].message).to be == "Standard error"
+		end
+		
+		it "handles ArgumentError" do
+			error = ArgumentError.new("Invalid argument")
+			write_message({error: error})
+			
+			result = read_message
+			expect(result[:error]).to be_a(ArgumentError)
+			expect(result[:error].message).to be == "Invalid argument"
+		end
+	end
+	
+	with "normalize method" do
+		it "normalizes objects with as_json method" do
+			obj = TrueObject.new
+			write_message({custom: obj})
+			
+			result = read_message
+			expect(result[:custom]).to be == true
+		end
+		
+		it "normalizes arrays of objects with as_json" do
+			write_message({items: [TrueObject.new, TrueObject.new]})
+			
+			result = read_message
+			expect(result[:items]).to be == [true, true]
+		end
+		
+		it "normalizes nested objects with as_json" do
+			write_message({
+				data: {
+					flag: TrueObject.new,
+					nested: {
+						another: TrueObject.new
+					}
+				}
+			})
+			
+			result = read_message
+			expect(result[:data][:flag]).to be == true
+			expect(result[:data][:nested][:another]).to be == true
+		end
+	end
+	
+	with "complex messages" do
+		it "handles complex nested structures" do
+			write_message({
+				id: 123,
+				action: :process,
+				data: {
+					items: [1, 2, 3],
+					metadata: {
+						timestamp: Time.now,
+						type: String
+					}
+				},
+				flags: {
+					active: true,
+					debug: false
+				}
+			})
+			
+			result = read_message
+			expect(result[:id]).to be == 123
+			expect(result[:action]).to be == :process
+			expect(result[:data][:items]).to be == [1, 2, 3]
+			expect(result[:flags][:active]).to be == true
+		end
+		
+		it "handles large arrays" do
+			large_array = (1..1000).to_a
+			write_message({data: large_array})
+			
+			result = read_message
+			expect(result[:data]).to be == large_array
+		end
+		
+		it "handles deeply nested structures" do
+			deep = {level1: {level2: {level3: {level4: {level5: "deep"}}}}}
+			write_message(deep)
+			
+			result = read_message
+			expect(result[:level1][:level2][:level3][:level4][:level5]).to be == "deep"
+		end
+	end
+	
+	with "edge cases" do
+		it "handles empty string" do
+			write_message({text: ""})
+			
+			result = read_message
+			expect(result[:text]).to be == ""
+		end
+		
+		it "handles zero values" do
+			write_message({count: 0, amount: 0.0})
+			
+			result = read_message
+			expect(result[:count]).to be == 0
+			expect(result[:amount]).to be == 0.0
+		end
+		
+		it "handles unicode strings" do
+			write_message({text: "Hello 世界 🌍"})
+			
+			result = read_message
+			expect(result[:text]).to be == "Hello 世界 🌍"
+		end
+		
+		it "handles special characters" do
+			write_message({text: "Line1\nLine2\tTabbed"})
+			
+			result = read_message
+			expect(result[:text]).to be == "Line1\nLine2\tTabbed"
+		end
+	end
+end

--- a/test/async/container/message_wrapper.rb
+++ b/test/async/container/message_wrapper.rb
@@ -41,6 +41,16 @@ describe Async::Container::Supervisor::MessageWrapper do
 			Integer.send(:remove_method, :as_json)
 		end
 		
+		it "normalizes circular references" do
+			array = []
+			array << array
+			
+			write_message({data: array})
+			
+			result = read_message
+			expect(result[:data]).to be == ["..."]
+		end
+		
 		it "handles simple strings" do
 			write_message({message: "hello world"})
 			

--- a/test/async/container/server.rb
+++ b/test/async/container/server.rb
@@ -10,25 +10,12 @@ describe Async::Container::Supervisor::Server do
 	include Async::Container::Supervisor::AServer
 	include Sus::Fixtures::Console::CapturedLogger
 	
-	let(:message_wrapper) {Async::Container::Supervisor::MessageWrapper.new}
-	
-	# Helper to write length-prefixed MessagePack data
 	def write_message(stream, message)
-		data = message_wrapper.pack(message)
-		stream.write([data.bytesize].pack("N") + data)
-		stream.flush
+		Async::Container::Supervisor::MessageWrapper.new(stream).write(message)
 	end
 	
-	# Helper to read length-prefixed MessagePack data
 	def read_message(stream)
-		length_data = stream.read(4)
-		return nil unless length_data && length_data.bytesize == 4
-		
-		length = length_data.unpack1("N")
-		data = stream.read(length)
-		return nil unless data && data.bytesize == length
-		
-		message_wrapper.unpack(data)
+		Async::Container::Supervisor::MessageWrapper.new(stream).read
 	end
 	
 	it "can handle unexpected failures" do


### PR DESCRIPTION
## Types of Changes

- Bug fix.
- New feature.
- Performance improvement.

## PR Summary

Instead of using JSON string for communicating between supervisor and workers, use [MessagePack](https://github.com/msgpack/msgpack-ruby) instead for better performance and String safety.

`Async::Container::Supervisor::MessageWrapper` has been newly introduced to this gem.
The `MessageWrapper` normalizes the message object by invoking the message object's `as_json` function.

`Connection` uses the new `MessageWrapper` and for now I have configured it to have 4GiB. (maximum value from unsigned 32-bit int / may be unsigned 16-bit int with 65KB will be enough 🤔)

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
